### PR TITLE
Bumped Selenium version to 2.48.2 to support Firefox 41.0.2 (as of now)

### DIFF
--- a/etsy-selenium/groovy-pico/pom.xml
+++ b/etsy-selenium/groovy-pico/pom.xml
@@ -13,7 +13,7 @@
     <jbehave.web.version>3.6-SNAPSHOT</jbehave.web.version>
     <jbehave.site.version>3.3</jbehave.site.version>
     <fluent.selenium.version>1.14.5</fluent.selenium.version>
-    <selenium.version>2.40.0</selenium.version>
+    <selenium.version>2.48.2</selenium.version>
     <gmaven.version>1.3</gmaven.version>
     <groovy.version>1.8.6</groovy.version>
     <ignore.failures>true</ignore.failures>

--- a/etsy-selenium/java-spring/pom.xml
+++ b/etsy-selenium/java-spring/pom.xml
@@ -13,7 +13,7 @@
     <jbehave.web.version>3.6-SNAPSHOT</jbehave.web.version>
     <jbehave.site.version>3.3</jbehave.site.version>
     <fluent.selenium.version>1.14.5</fluent.selenium.version>
-    <selenium.version>2.40.0</selenium.version>
+    <selenium.version>2.48.2</selenium.version>
     <ignore.failures>true</ignore.failures>
     <meta.filter></meta.filter>
     <threads>1</threads>


### PR DESCRIPTION
The tutorial does not work out of the box with the latest Firefox 41.0.2 (as of now). To make the JBehave learning a bit smoother for newcomers this PR has been raised.

Please review.